### PR TITLE
Reduce supervisor image size and auto-center faces

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -3,6 +3,13 @@ import yaml
 from jinja2 import Environment, FileSystemLoader
 from weasyprint import HTML
 
+# Optional dependencies for image smart centering
+try:  # pragma: no cover - if unavailable we skip centering
+    from PIL import Image, ImageFilter, ImageOps
+    import numpy as np
+except Exception:  # pragma: no cover - graceful degradation
+    Image = ImageFilter = ImageOps = np = None
+
 # ---------- Config ----------
 YAML_INPUT = "data/supervisors.yaml"
 PUBLIC_FOLDER = "public"
@@ -12,6 +19,31 @@ SITE_BASE_PATH = "/supervisor-portfolio"
 DEFAULT_LOGO_FILENAME = "AboAkademiUniversity.png"
 DEFAULT_LOGO = f"{SITE_BASE_PATH}/images/{DEFAULT_LOGO_FILENAME}"
 DEFAULT_LOGO_PDF = os.path.abspath(os.path.join(IMAGES_FOLDER, DEFAULT_LOGO_FILENAME))
+
+
+def center_face(image_path: str) -> None:
+    """Center the most "interesting" part of an image in a square crop.
+
+    This uses a lightweight edge-based heuristic when Pillow and NumPy are
+    available.  If the optional dependencies are missing or no edges are
+    detected, the image is left unchanged.
+    """
+    if Image is None or np is None:
+        return
+
+    with Image.open(image_path) as img:
+        size = min(img.size)
+        gray = img.convert("L")
+        edges = gray.filter(ImageFilter.FIND_EDGES)
+        arr = np.array(edges)
+        ys, xs = np.nonzero(arr)
+        if len(xs) == 0:
+            # No strong edges detected – keep as-is
+            return
+        cx = xs.mean() / arr.shape[1]
+        cy = ys.mean() / arr.shape[0]
+        cropped = ImageOps.fit(img, (size, size), centering=(cx, cy))
+        cropped.save(image_path)
 
 # ---------- Load templates ----------
 env = Environment(loader=FileSystemLoader("src/templates"))
@@ -33,6 +65,8 @@ for supervisor in supervisors:
         candidate = slug + ext
         full_path = os.path.join(IMAGES_FOLDER, candidate)
         if os.path.isfile(full_path):
+            # Attempt to center the face in the image before using it
+            center_face(full_path)
             supervisor["photo_url"] = f"{SITE_BASE_PATH}/images/{candidate}"
             supervisor["photo_pdf_path"] = os.path.abspath(full_path)
             found = True

--- a/src/templates/pdf.html
+++ b/src/templates/pdf.html
@@ -32,20 +32,20 @@
     }
     .unit-grid {
       display: grid;
-      grid-template-columns: repeat(6, 1fr);
-      gap: 10px;
+      grid-template-columns: repeat(8, 1fr);
+      gap: 6px;
       justify-items: center;
-      margin-top: 10px;
+      margin-top: 8px;
     }
     .unit-grid a {
       text-decoration: none;
       color: #0077cc;
-      font-size: 11px;
+      font-size: 9px;
       text-align: center;
     }
     .unit-grid img {
-      width: 90px;
-      height: 90px;
+      width: 60px;
+      height: 60px;
       object-fit: cover;
       border-radius: 4px;
       border: 1px solid #ccc;
@@ -53,7 +53,7 @@
     }
     .unit-grid span {
       display: block;
-      margin-top: 4px;
+      margin-top: 2px;
     }
     .supervisor {
       margin-top: 20px;
@@ -66,8 +66,9 @@
       margin-bottom: 10px;
     }
     .profile-header img {
-      width: 90px;
-      height: auto;
+      width: 75px;
+      height: 75px;
+      object-fit: cover;
       border-radius: 4px;
       background: #f4f4f4;
       flex-shrink: 0;


### PR DESCRIPTION
## Summary
- Keep full-sized (150 px) supervisor thumbnails on the website but retain smaller images in the PDF layout
- Replace failing OpenCV face detection with a lightweight edge-based heuristic for centering images using Pillow/NumPy

## Testing
- `pip install --quiet Pillow numpy pyyaml weasyprint` *(failed: Could not find a version that satisfies the requirement Pillow)*
- `python src/build.py` *(failed: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_68bd86d199808329804f992d01ef7e8c