### PR TITLE
Center supervisor images and use square thumbnails

### DIFF
--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -73,8 +73,9 @@
 
     .supervisor-card img {
       width: 120px;
-      height: 120px;
+      aspect-ratio: 1 / 1;
       object-fit: cover;
+      object-position: center;
       border-radius: 8px;
       border: 2px solid #ccc;
       background-color: #f9f9f9;

--- a/src/templates/supervisor.html
+++ b/src/templates/supervisor.html
@@ -26,30 +26,26 @@
     }
     .profile-header {
       display: flex;
-      flex-wrap: wrap;
-      align-items: flex-start;
-      justify-content: space-between;
+      flex-direction: column;
+      align-items: center;
       margin-bottom: 30px;
     }
     .profile-left {
       display: flex;
-      flex-wrap: wrap;
+      flex-direction: column;
       align-items: center;
       gap: 20px;
-      flex: 1;
     }
     .profile-photo {
-      width: 140px;
-      max-width: 100%;
+      max-width: 200px;
+      width: 100%;
       height: auto;
       border-radius: 10px;
       border: 2px solid #ccc;
       background-color: #f9f9f9;
-      flex-shrink: 0;
     }
     .profile-info {
-      flex: 1;
-      min-width: 200px;
+      text-align: center;
     }
     .profile-info h1 {
       margin: 0;
@@ -95,18 +91,6 @@
     }
 
     @media (max-width: 600px) {
-      .profile-header {
-        flex-direction: column;
-        align-items: center;
-        text-align: center;
-      }
-      .profile-left {
-        flex-direction: column;
-        align-items: center;
-      }
-      .profile-info h1 {
-        font-size: 22px;
-      }
       .logo {
         display: none;
       }


### PR DESCRIPTION
## Summary
- Display square thumbnails on the index via CSS `aspect-ratio`
- Center supervisor photos and info vertically on profile pages without cropping

## Testing
- ⚠️ `python src/build.py` (fails: IndentationError: unexpected indent)


------
https://chatgpt.com/codex/tasks/task_b_68bd8ae8e2e48329a0451728e9e45a56